### PR TITLE
Remove "throw"s from comparators

### DIFF
--- a/lib/Rules.js
+++ b/lib/Rules.js
@@ -23,7 +23,7 @@ Rules.prototype.run = function(data) {
       throw new Error("rules must have an `if` and `then` object");
     }
 
-    if (this.testsPass(rule["if"], data)) {
+    if (this.testsMatch(rule["if"], data)) {
       this.runOutcomes(rule.then, outcomeResults);
     }
   }
@@ -31,14 +31,18 @@ Rules.prototype.run = function(data) {
   return outcomeResults;
 };
 
-Rules.prototype.testsPass = function(tests, data){
+Rules.prototype.testsMatch = function(tests, data){
   var expected, actual;
   var testKeys = Object.keys(tests);
 
   //if any test is false, return
   for (var i = 0; i < testKeys.length; i++) {
-    if (this.opts.strict && !path.has(data, testKeys[i])) {
+    var hasValue = path.has(data, testKeys[i]);
+
+    if (this.opts.strict && !hasValue) {
       throw new Error("Value does not exist in data:" + testKeys[i]);
+    } else if (!hasValue) {
+      return;
     }
 
     expected = tests[testKeys[i]];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rules-runner",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A JS business rules engine for node",
   "keywords": [
     "business rules",

--- a/test/Rules.js
+++ b/test/Rules.js
@@ -120,6 +120,27 @@ describe("Rules", function() {
       rules.run(data);
     }, "should throw path errors with strict:false");
   });
+
+  it("doesn't run tests for path errors with strict:false", function() {
+    var config = {
+      "name must be set": {
+        if: {
+          "person.age": { between: [10,20] }
+        },
+        then: {
+          "errors[]": "Must be between 10 and 20"
+        },
+      },
+    };
+
+    var data = {
+      person: {
+        name: "Bob"
+      },
+    };
+    var rules = new Rules(config);
+    rules.run(data);
+  });
 });
 
 describe("options", function() {


### PR DESCRIPTION
If the deep object doesn't exist (e.g. `data.educationLevel.master.weight` because `data.educationLevel` is `null` or `undefined`), it's best just to return `false` rather than `throw new Error(...)` in:

- `lessThan`
- `greaterThan`
- `between`
- `contains`
- `in`
