### PR TITLE
Ability to have multiple if conditions acting as OR conditions, and an elseThen outcome if rules prove false

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/README.md
+++ b/README.md
@@ -60,6 +60,68 @@ assert.deepEqual(data.errors.all, ["person", "company"]);
 //var results = rules.run(data, {rulesModifyData: false});
 ```
 
+
+#Also possible to test a series of if statements in an Array, as OR like conditionals
+
+```js
+
+var config = {
+    "Person will be in house if person is tired or hungry": {
+            if: [
+                {"person.tired": true},
+                {"person.hungry": true}
+            ],
+            then: {
+                "person.location": "house"
+            }
+        }
+    };
+    
+    var data = {
+        person: {
+            tired: false,
+            hungry: true
+        }
+    };
+    
+    var rules = new Rules(config);
+    rules.run(data);
+    
+    assert.equal(data.person.location, 'house');
+```
+
+#And if no conditions are true, then process an elseThen clause
+
+
+```js
+
+var config = {
+            "Person will be in house if person is tired or hungry": {
+                if: [
+                    {"person.tired": true},
+                    {"person.hungry": true}
+                ],
+                then: {
+                    "person.location": "house"
+                },
+                elseThen: { // if all conditions are false
+                    "person.location": 'work'
+                }
+            }
+        };
+        var data = {
+            person: {
+                tired: false,
+                hungry: false
+            }
+        };
+
+        var rules = new Rules(config);
+        rules.run(data);
+
+        assert.equal(data.person.location, 'work');
+```
+
 # Comparators/Tests
 - **between**: `"person.age": {between: [1, 20]}`
 - **equality/scalar values**: `"person.exists": true` `"person.firstName": "John"`

--- a/README.md
+++ b/README.md
@@ -77,49 +77,49 @@ var config = {
         }
     };
     
-    var data = {
-        person: {
-            tired: false,
-            hungry: true
-        }
-    };
-    
-    var rules = new Rules(config);
-    rules.run(data);
-    
-    assert.equal(data.person.location, 'house');
+var data = {
+    person: {
+        tired: false,
+        hungry: true
+    }
+};
+
+var rules = new Rules(config);
+rules.run(data);
+
+assert.equal(data.person.location, 'house');
 ```
 
-#And if no conditions are true, then process an elseThen clause
+#And if no conditions are true, then process an `otherwise` clause
 
 
 ```js
 
 var config = {
-            "Person will be in house if person is tired or hungry": {
-                if: [
-                    {"person.tired": true},
-                    {"person.hungry": true}
-                ],
-                then: {
-                    "person.location": "house"
-                },
-                elseThen: { // if all conditions are false
-                    "person.location": 'work'
-                }
-            }
-        };
-        var data = {
-            person: {
-                tired: false,
-                hungry: false
-            }
-        };
+    "Person will be in house if person is tired or hungry": {
+        if: [
+            {"person.tired": true},
+            {"person.hungry": true}
+        ],
+        then: {
+            "person.location": "house"
+        },
+        otherwise: { // if all conditions are false
+            "person.location": 'work'
+        }
+    }
+};
+var data = {
+    person: {
+        tired: false,
+        hungry: false
+    }
+};
 
-        var rules = new Rules(config);
-        rules.run(data);
+var rules = new Rules(config);
+rules.run(data);
 
-        assert.equal(data.person.location, 'work');
+assert.equal(data.person.location, 'work');
 ```
 
 # Comparators/Tests

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ var config = {
 ```
 
 # Comparators/Tests
-- **between**: `"person.age": {between: [1, 20]}`
+- **between**: `"person.age": {between: [1, 20]}` (note: this is exclusive of given values)
 - **equality/scalar values**: `"person.exists": true` `"person.firstName": "John"`
 - **contains**: `"person.name": {contains: "Jr"}`` (also checks for values in arrays)
 - **greaterThan**: `"person.age": {greaterThan: 20}`

--- a/lib/Rules.js
+++ b/lib/Rules.js
@@ -1,7 +1,7 @@
 var assign = require("object-assign");
 var comparators = require("./comparator");
 var path = require("object-path");
-var _ = require('lodash');
+var _ = require("lodash");
 
 function Rules(config, opts) {
   this.config = config;
@@ -37,16 +37,16 @@ Rules.prototype.run = function(data) {
     }
     else if (_.isArray(rule["if"])) { // can track N number of rule sets, i.e. series of OR conditions
 
-      var trackFailedValidation = [],
-          self = this,
-          iterFunc = function (item) {
+      var trackFailedValidation = [];
 
-            if (!self.testsMatch(item, data)) {
-              self.trackFailedValidation.push(true);
-            }
-          };
+      for (var j = 0; j < rule["if"].length; j++) {
 
-      rule["if"].forEach(iterFunc);
+        var item = rule["if"][j];
+        
+        if (!this.testsMatch(item, data)) {
+          trackFailedValidation.push(true);
+        }
+      }
 
       // number of failed rules is same length as all rules, none passed as true
       if (trackFailedValidation.length === rule["if"].length) {

--- a/lib/Rules.js
+++ b/lib/Rules.js
@@ -38,17 +38,18 @@ Rules.prototype.run = function(data) {
     else if (_.isArray(rule["if"])) { // can track N number of rule sets, i.e. series of OR conditions
 
       var trackFailedValidation = [],
-          self = this;
+          self = this,
+          iterFunc = function (item) {
 
-      rule['if'].forEach(function (item) {
+            if (!self.testsMatch(item, data)) {
+              self.trackFailedValidation.push(true);
+            }
+          };
 
-        if (!self.testsMatch(item, data)) {
-          trackFailedValidation.push(true);
-        }
-      });
+      rule["if"].forEach(iterFunc);
 
       // number of failed rules is same length as all rules, none passed as true
-      if (trackFailedValidation.length === rule['if'].length) {
+      if (trackFailedValidation.length === rule["if"].length) {
         if (rule.elseThen) {
           this.runOutcomes(rule.elseThen, outcomeResults);
         }

--- a/lib/Rules.js
+++ b/lib/Rules.js
@@ -1,7 +1,6 @@
 var assign = require("object-assign");
 var comparators = require("./comparator");
 var path = require("object-path");
-var _ = require("lodash");
 
 function Rules(config, opts) {
   this.config = config;
@@ -10,50 +9,54 @@ function Rules(config, opts) {
     rulesModifyData: true,
     stringNumbers: true,
     caseSensitive: true,
-    strict: false,
+    strict: false
   }, opts || {});
 }
 
 Rules.prototype.run = function(data) {
   var outcomeResults = (this.opts.rulesModifyData) ? data : {};
   var rules = Object.keys(this.config);
+
   for (var i = 0; i < rules.length; i++) {
-    var rule = this.config[rules[i]];
+    var rule = this.config[rules[i]],
+      isRulesArray;
 
     if (!rule["if"] || !rule.then) {
       throw new Error("rules must have an `if` and `then` object");
     }
 
-    if (_.isPlainObject(rule["if"])) {
+    isRulesArray = Object.prototype.toString.call(rule["if"]) === '[object Array]';
+
+    if (!isRulesArray) {
 
       if (this.testsMatch(rule["if"], data)) {
         this.runOutcomes(rule.then, outcomeResults);
       }
       else {
-        if (rule.elseThen) {
-          this.runOutcomes(rule.elseThen, outcomeResults);
+        if (rule.otherwise) {
+          this.runOutcomes(rule.otherwise, outcomeResults);
         }
       }
     }
-    else if (_.isArray(rule["if"])) { // can track N number of rule sets, i.e. series of OR conditions
-
-      var trackFailedValidation = [];
+    else if (isRulesArray) { // can track N number of rule sets, i.e. series of OR conditions
+      var passes = false;
 
       for (var j = 0; j < rule["if"].length; j++) {
         var item = rule["if"][j];
-        if (!this.testsMatch(item, data)) {
-          trackFailedValidation.push(true);
+        if (this.testsMatch(item, data)) {
+          passes = true;
+          break;
         }
       }
 
       // number of failed rules is same length as all rules, none passed as true
-      if (trackFailedValidation.length === rule["if"].length) {
-        if (rule.elseThen) {
-          this.runOutcomes(rule.elseThen, outcomeResults);
-        }
+      if (passes) {
+        this.runOutcomes(rule.then, outcomeResults);
       }
       else {
-        this.runOutcomes(rule.then, outcomeResults);
+        if (rule.otherwise) {
+          this.runOutcomes(rule.otherwise, outcomeResults);
+        }
       }
     }
   }

--- a/lib/Rules.js
+++ b/lib/Rules.js
@@ -48,8 +48,7 @@ Rules.prototype.run = function(data) {
           break;
         }
       }
-
-      // number of failed rules is same length as all rules, none passed as true
+      
       if (passes) {
         this.runOutcomes(rule.then, outcomeResults);
       }

--- a/lib/Rules.js
+++ b/lib/Rules.js
@@ -1,6 +1,7 @@
 var assign = require("object-assign");
 var comparators = require("./comparator");
 var path = require("object-path");
+var _ = require('lodash');
 
 function Rules(config, opts) {
   this.config = config;
@@ -23,17 +24,9 @@ Rules.prototype.run = function(data) {
       throw new Error("rules must have an `if` and `then` object");
     }
 
-    if (this.testsMatch(rule["if"], data)) {
-      this.runOutcomes(rule.then, outcomeResults);
-    }
-    else {
-      if (rule.elseThen) {
-        this.runOutcomes(rule.elseThen, outcomeResults);
-      }
-    }
+    if (_.isPlainObject(rule["if"])) {
 
-    if (rule["elseif"]) {
-      if (this.testsMatch(rule["elseif"], data)) {
+      if (this.testsMatch(rule["if"], data)) {
         this.runOutcomes(rule.then, outcomeResults);
       }
       else {
@@ -42,7 +35,28 @@ Rules.prototype.run = function(data) {
         }
       }
     }
+    else if (_.isArray(rule["if"])) { // can track N number of rule sets, i.e. series of OR conditions
 
+      var trackFailedValidation = [],
+          self = this;
+
+      rule['if'].forEach(function (item) {
+
+        if (!self.testsMatch(item, data)) {
+          trackFailedValidation.push(true);
+        }
+      });
+
+      // number of failed rules is same length as all rules, none passed as true
+      if (trackFailedValidation.length === rule['if'].length) {
+        if (rule.elseThen) {
+          this.runOutcomes(rule.elseThen, outcomeResults);
+        }
+      }
+      else {
+        this.runOutcomes(rule.then, outcomeResults);
+      }
+    }
   }
 
   return outcomeResults;

--- a/lib/Rules.js
+++ b/lib/Rules.js
@@ -25,7 +25,7 @@ Rules.prototype.run = function(data) {
       throw new Error("rules must have an `if` and `then` object");
     }
 
-    isRulesArray = Object.prototype.toString.call(rule["if"]) === '[object Array]';
+    isRulesArray = Object.prototype.toString.call(rule["if"]) === "[object Array]";
 
     if (!isRulesArray) {
 

--- a/lib/Rules.js
+++ b/lib/Rules.js
@@ -26,6 +26,13 @@ Rules.prototype.run = function(data) {
     if (this.testsMatch(rule["if"], data)) {
       this.runOutcomes(rule.then, outcomeResults);
     }
+
+    if (rule["elseif"]) {
+      if (this.testsMatch(rule["elseif"], data)) {
+        this.runOutcomes(rule.then, outcomeResults);
+      }
+    }
+
   }
 
   return outcomeResults;

--- a/lib/Rules.js
+++ b/lib/Rules.js
@@ -26,10 +26,20 @@ Rules.prototype.run = function(data) {
     if (this.testsMatch(rule["if"], data)) {
       this.runOutcomes(rule.then, outcomeResults);
     }
+    else {
+      if (rule.elseThen) {
+        this.runOutcomes(rule.elseThen, outcomeResults);
+      }
+    }
 
     if (rule["elseif"]) {
       if (this.testsMatch(rule["elseif"], data)) {
         this.runOutcomes(rule.then, outcomeResults);
+      }
+      else {
+        if (rule.elseThen) {
+          this.runOutcomes(rule.elseThen, outcomeResults);
+        }
       }
     }
 

--- a/lib/Rules.js
+++ b/lib/Rules.js
@@ -40,9 +40,7 @@ Rules.prototype.run = function(data) {
       var trackFailedValidation = [];
 
       for (var j = 0; j < rule["if"].length; j++) {
-
         var item = rule["if"][j];
-        
         if (!this.testsMatch(item, data)) {
           trackFailedValidation.push(true);
         }

--- a/lib/Rules.js
+++ b/lib/Rules.js
@@ -48,7 +48,7 @@ Rules.prototype.run = function(data) {
           break;
         }
       }
-      
+
       if (passes) {
         this.runOutcomes(rule.then, outcomeResults);
       }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "mocha": "^2.2.4"
   },
   "dependencies": {
+    "lodash": "^3.10.0",
     "object-assign": "^2.0.0",
     "object-path": "^0.9.2"
   }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "mocha": "^2.2.4"
   },
   "dependencies": {
-    "lodash": "^3.10.0",
     "object-assign": "^2.0.0",
     "object-path": "^0.9.2"
   }

--- a/test/Rules.js
+++ b/test/Rules.js
@@ -96,7 +96,7 @@ describe("Rules", function () {
     assert.equal(data.person.location, "house");
   });
 
-  it("tests a series of if (OR) conditions, and makes elseThen outcome if all fail", function () {
+  it("tests a series of if (OR) conditions, and applies `otherwise` outcome if all fail", function () {
     var config = {
       "Person will be in house if person is tired or hungry": {
         if: [

--- a/test/Rules.js
+++ b/test/Rules.js
@@ -2,335 +2,335 @@ var assert = require("assert");
 var Rules = require("../lib/Rules");
 
 describe("Rules", function () {
-    it("populates multiple outcomes", function () {
-        var config = {
-            "Must be 21 or older": {
-                if: {
-                    "person.age": {
-                        lessThan: 21
-                    }
-                },
-                then: {
-                    "person.error": "Must be 21 or older",
-                    "errors.all[]": "person"
-                }
-            },
-            "Must be employed": {
-                if: {
-                    "company.isEmployed": false
-                },
-                then: {
-                    "company.error": "Must be employed",
-                    "errors.all[]": "company"
-                }
-            }
-        };
-        var data = {
-            person: {
-                age: 20
-            },
-            company: {
-                isEmployed: false
-            }
-        };
+  it("populates multiple outcomes", function () {
+    var config = {
+      "Must be 21 or older": {
+        if: {
+          "person.age": {
+            lessThan: 21
+          }
+        },
+        then: {
+          "person.error": "Must be 21 or older",
+          "errors.all[]": "person"
+        }
+      },
+      "Must be employed": {
+        if: {
+          "company.isEmployed": false
+        },
+        then: {
+          "company.error": "Must be employed",
+          "errors.all[]": "company"
+        }
+      }
+    };
+    var data = {
+      person: {
+        age: 20
+      },
+      company: {
+        isEmployed: false
+      }
+    };
 
-        var rules = new Rules(config);
-        var results = rules.run(data);
-        assert.equal(results.person.error, "Must be 21 or older");
-        assert.deepEqual(results.errors.all, ["person", "company"]);
-    });
+    var rules = new Rules(config);
+    var results = rules.run(data);
+    assert.equal(results.person.error, "Must be 21 or older");
+    assert.deepEqual(results.errors.all, ["person", "company"]);
+  });
 
 
-    it('tests alternative outcome if rule validation comes back false', function () {
-        var config = {
-            "Person will be in house if person is tired or hungry": {
-                if: {
-                    "person.tired": true
-                },
-                then: {
-                    "person.location": "house"
-                },
-                elseThen: {
-                    "person.location": 'work'
-                }
-            }
-        };
-        var data = {
-            person: {
-                tired: false,
-                hungry: false
-            }
-        };
+  it("tests alternative outcome if rule validation comes back false", function () {
+    var config = {
+      "Person will be in house if person is tired or hungry": {
+        if: {
+          "person.tired": true
+        },
+        then: {
+          "person.location": "house"
+        },
+        otherwise: {
+          "person.location": "work"
+        }
+      }
+    };
+    var data = {
+      person: {
+        tired: false,
+        hungry: false
+      }
+    };
 
-        var rules = new Rules(config);
-        rules.run(data);
+    var rules = new Rules(config);
+    rules.run(data);
 
-        assert.equal(data.person.location, 'work');
-    });
+    assert.equal(data.person.location, "work");
+  });
 
-    it('tests a series of if conditions (Array), as separate OR rules', function () {
-        var config = {
-            "Person will be in house if person is tired or hungry": {
-                if: [
-                    {"person.tired": true},
-                    {"person.hungry": true}
-                ],
-                then: {
-                    "person.location": "house"
-                },
-                elseThen: {
-                    "person.location": 'work'
-                }
-            }
-        };
-        var data = {
-            person: {
-                tired: false,
-                hungry: true
-            }
-        };
+  it("tests a series of if conditions (Array), as separate OR rules", function () {
+    var config = {
+      "Person will be in house if person is tired or hungry": {
+        if: [
+          {"person.tired": true},
+          {"person.hungry": true}
+        ],
+        then: {
+          "person.location": "house"
+        },
+        otherwise: {
+          "person.location": 'work'
+        }
+      }
+    };
+    var data = {
+      person: {
+        tired: false,
+        hungry: true
+      }
+    };
 
-        var rules = new Rules(config);
-        rules.run(data);
+    var rules = new Rules(config);
+    rules.run(data);
 
-        assert.equal(data.person.location, 'house');
-    });
+    assert.equal(data.person.location, "house");
+  });
 
-    it('tests a series of if (OR) conditions, and makes elseThen outcome if all fail', function () {
-        var config = {
-            "Person will be in house if person is tired or hungry": {
-                if: [
-                    {"person.tired": true},
-                    {"person.hungry": true}
-                ],
-                then: {
-                    "person.location": "house"
-                },
-                elseThen: {
-                    "person.location": 'work'
-                }
-            }
-        };
-        var data = {
-            person: {
-                tired: false,
-                hungry: false
-            }
-        };
+  it("tests a series of if (OR) conditions, and makes elseThen outcome if all fail", function () {
+    var config = {
+      "Person will be in house if person is tired or hungry": {
+        if: [
+          {"person.tired": true},
+          {"person.hungry": true}
+        ],
+        then: {
+          "person.location": "house"
+        },
+        otherwise: {
+          "person.location": "work"
+        }
+      }
+    };
+    var data = {
+      person: {
+        tired: false,
+        hungry: false
+      }
+    };
 
-        var rules = new Rules(config);
-        rules.run(data);
+    var rules = new Rules(config);
+    rules.run(data);
 
-        assert.equal(data.person.location, 'work');
-    });
+    assert.equal(data.person.location, "work");
+  });
 
-    it("populates multiple outcomes into an array when [] is added", function () {
-        var config = {
-            "Must be 21 or older": {
-                if: {
-                    "person.age": {lessThan: 21}
-                },
+  it("populates multiple outcomes into an array when [] is added", function () {
+    var config = {
+      "Must be 21 or older": {
+        if: {
+          "person.age": {lessThan: 21}
+        },
 
-                then: {
-                    "errors[]": "Must be 21 or older"
-                }
-            },
-            "Must be employed": {
-                if: {
-                    "person.isCitizen": false
-                },
-                then: {
-                    "errors[]": "Must be a citizen"
-                }
-            }
-        };
-        var data = {
-            person: {
-                age: 20,
-                isCitizen: false,
-            }
-        };
-        var rules = new Rules(config);
-        var results = rules.run(data);
+        then: {
+          "errors[]": "Must be 21 or older"
+        }
+      },
+      "Must be employed": {
+        if: {
+          "person.isCitizen": false
+        },
+        then: {
+          "errors[]": "Must be a citizen"
+        }
+      }
+    };
+    var data = {
+      person: {
+        age: 20,
+        isCitizen: false,
+      }
+    };
+    var rules = new Rules(config);
+    var results = rules.run(data);
 
-        assert.deepEqual(results.errors, [
-            "Must be 21 or older",
-            "Must be a citizen"
-        ]);
-    });
+    assert.deepEqual(results.errors, [
+      "Must be 21 or older",
+      "Must be a citizen"
+    ]);
+  });
 
-    it("doesn't throw path errors with strict:false", function () {
-        var config = {
-            "name must be set": {
-                if: {
-                    "person.name": {not: undefined}
-                },
-                then: {
-                    "errors[]": "Must have a name"
-                },
-            },
-        };
+  it("doesn't throw path errors with strict:false", function () {
+    var config = {
+      "name must be set": {
+        if: {
+          "person.name": {not: undefined}
+        },
+        then: {
+          "errors[]": "Must have a name"
+        },
+      },
+    };
 
-        var data = {
-            person: {
-                age: 34
-            },
-        };
-        var rules = new Rules(config);
-        assert.doesNotThrow(function () {
-            rules.run(data);
-        }, "should not throw path errors with strict:false");
-    });
+    var data = {
+      person: {
+        age: 34
+      },
+    };
+    var rules = new Rules(config);
+    assert.doesNotThrow(function () {
+      rules.run(data);
+    }, "should not throw path errors with strict:false");
+  });
 
-    it("throws path errors with strict:true", function () {
-        var config = {
-            "name must be set": {
-                if: {
-                    "person.name": {not: undefined}
-                },
-                then: {
-                    "errors[]": "Must have a name"
-                },
-            },
-        };
+  it("throws path errors with strict:true", function () {
+    var config = {
+      "name must be set": {
+        if: {
+          "person.name": {not: undefined}
+        },
+        then: {
+          "errors[]": "Must have a name"
+        },
+      },
+    };
 
-        var data = {
-            person: {
-                age: 34
-            },
-        };
-        var rules = new Rules(config, {strict: true});
-        assert.throws(function () {
-            rules.run(data);
-        }, "should throw path errors with strict:false");
-    });
+    var data = {
+      person: {
+        age: 34
+      },
+    };
+    var rules = new Rules(config, {strict: true});
+    assert.throws(function () {
+      rules.run(data);
+    }, "should throw path errors with strict:false");
+  });
 
-    it("doesn't run tests for path errors with strict:false", function () {
-        var config = {
-            "name must be set": {
-                if: {
-                    "person.age": {between: [10, 20]}
-                },
-                then: {
-                    "errors[]": "Must be between 10 and 20"
-                },
-            },
-        };
+  it("doesn't run tests for path errors with strict:false", function () {
+    var config = {
+      "name must be set": {
+        if: {
+          "person.age": {between: [10, 20]}
+        },
+        then: {
+          "errors[]": "Must be between 10 and 20"
+        },
+      },
+    };
 
-        var data = {
-            person: {
-                name: "Bob"
-            },
-        };
-        var rules = new Rules(config);
-        rules.run(data);
-    });
+    var data = {
+      person: {
+        name: "Bob"
+      },
+    };
+    var rules = new Rules(config);
+    rules.run(data);
+  });
 });
 
 describe("options", function () {
-    it("stringNumbers: false prevents parsing of numbers", function () {
-        var data = {age: "14"};
+  it("stringNumbers: false prevents parsing of numbers", function () {
+    var data = {age: "14"};
 
-        var config = {
-            "Younger than 16 can't drive": {
-                if: {
-                    "age": {lessThan: 16}
-                },
-                then: {
-                    "canDrive": false
-                }
-            }
-        };
-
-        var rules = new Rules(config, {stringNumbers: false});
-        var error;
-        try {
-            rules.run(data);
-        } catch (e) {
-            error = true;
+    var config = {
+      "Younger than 16 can't drive": {
+        if: {
+          "age": {lessThan: 16}
+        },
+        then: {
+          "canDrive": false
         }
+      }
+    };
 
-        assert(error);
-    });
+    var rules = new Rules(config, {stringNumbers: false});
+    var error;
+    try {
+      rules.run(data);
+    } catch (e) {
+      error = true;
+    }
 
-    it("rulesModifyData: false creates new object of rule outcomes", function () {
-        var data = {age: 15};
+    assert(error);
+  });
 
-        var config = {
-            "Younger than 16 can't drive": {
-                if: {
-                    "age": {lessThan: 16}
-                },
-                then: {
-                    "cantDrive": true
-                }
-            }
-        };
+  it("rulesModifyData: false creates new object of rule outcomes", function () {
+    var data = {age: 15};
 
-        var rules = new Rules(config, {rulesModifyData: false});
-        var results = rules.run(data);
+    var config = {
+      "Younger than 16 can't drive": {
+        if: {
+          "age": {lessThan: 16}
+        },
+        then: {
+          "cantDrive": true
+        }
+      }
+    };
 
-        assert.equal(results.cantDrive, true);
-        assert.equal(data.cantDrive, undefined);
-    });
+    var rules = new Rules(config, {rulesModifyData: false});
+    var results = rules.run(data);
 
-    it("rulesModifyData: true modifies data with outcomes", function () {
-        var data = {age: 15};
+    assert.equal(results.cantDrive, true);
+    assert.equal(data.cantDrive, undefined);
+  });
 
-        var config = {
-            "Younger than 16 can't drive": {
-                if: {
-                    "age": {lessThan: 16}
-                },
-                then: {
-                    "cantDrive": true
-                }
-            }
-        };
+  it("rulesModifyData: true modifies data with outcomes", function () {
+    var data = {age: 15};
 
-        var rules = new Rules(config, {rulesModifyData: true});
-        rules.run(data);
+    var config = {
+      "Younger than 16 can't drive": {
+        if: {
+          "age": {lessThan: 16}
+        },
+        then: {
+          "cantDrive": true
+        }
+      }
+    };
 
-        assert.equal(data.cantDrive, true);
-    });
+    var rules = new Rules(config, {rulesModifyData: true});
+    rules.run(data);
 
-    it("caseSensitive: false ignores case on contains", function () {
-        var data = {
-            person: {jobDescription: "Nursing management and oversight"}
-        };
+    assert.equal(data.cantDrive, true);
+  });
 
-        var config = {
-            "Anything to do with nursing is a good thing": {
-                if: {
-                    "person.jobDescription": {contains: "nursing"}
-                },
-                then: {"status.hasGoodJob": true}
-            }
-        };
+  it("caseSensitive: false ignores case on contains", function () {
+    var data = {
+      person: {jobDescription: "Nursing management and oversight"}
+    };
 
-        var rules = new Rules(config, {caseSensitive: false});
-        var results = rules.run(data);
+    var config = {
+      "Anything to do with nursing is a good thing": {
+        if: {
+          "person.jobDescription": {contains: "nursing"}
+        },
+        then: {"status.hasGoodJob": true}
+      }
+    };
 
-        assert.equal(results.status.hasGoodJob, true);
-    });
+    var rules = new Rules(config, {caseSensitive: false});
+    var results = rules.run(data);
 
-    it("caseSensitive: false ignores case on equality", function () {
-        var data = {
-            name: "John"
-        };
+    assert.equal(results.status.hasGoodJob, true);
+  });
 
-        var config = {
-            "John is a great name": {
-                if: {
-                    "name": "john"
-                },
-                then: {"status.hasGreatName": true}
-            }
-        };
+  it("caseSensitive: false ignores case on equality", function () {
+    var data = {
+      name: "John"
+    };
 
-        var rules = new Rules(config, {caseSensitive: false});
-        var results = rules.run(data);
+    var config = {
+      "John is a great name": {
+        if: {
+          "name": "john"
+        },
+        then: {"status.hasGreatName": true}
+      }
+    };
 
-        assert.equal(results.status.hasGreatName, true);
-    });
+    var rules = new Rules(config, {caseSensitive: false});
+    var results = rules.run(data);
+
+    assert.equal(results.status.hasGreatName, true);
+  });
 });

--- a/test/Rules.js
+++ b/test/Rules.js
@@ -1,279 +1,336 @@
 var assert = require("assert");
 var Rules = require("../lib/Rules");
 
-describe("Rules", function() {
-  it("populates multiple outcomes", function() {
-    var config = {
-      "Must be 21 or older": {
-        if: {
-          "person.age": {
-            lessThan: 21
-          }
-        },
-        then: {
-          "person.error": "Must be 21 or older",
-          "errors.all[]": "person"
-        }
-      },
-      "Must be employed": {
-        if: {
-          "company.isEmployed": false
-        },
-        then: {
-          "company.error": "Must be employed",
-          "errors.all[]": "company"
-        }
-      }
-    };
-    var data = {
-      person: {
-        age: 20
-      },
-      company: {
-        isEmployed: false
-      }
-    };
+describe("Rules", function () {
+    it("populates multiple outcomes", function () {
+        var config = {
+            "Must be 21 or older": {
+                if: {
+                    "person.age": {
+                        lessThan: 21
+                    }
+                },
+                then: {
+                    "person.error": "Must be 21 or older",
+                    "errors.all[]": "person"
+                }
+            },
+            "Must be employed": {
+                if: {
+                    "company.isEmployed": false
+                },
+                then: {
+                    "company.error": "Must be employed",
+                    "errors.all[]": "company"
+                }
+            }
+        };
+        var data = {
+            person: {
+                age: 20
+            },
+            company: {
+                isEmployed: false
+            }
+        };
 
-    var rules = new Rules(config);
-    var results = rules.run(data);
-    assert.equal(results.person.error, "Must be 21 or older");
-    assert.deepEqual(results.errors.all, ["person", "company"]);
-  });
+        var rules = new Rules(config);
+        var results = rules.run(data);
+        assert.equal(results.person.error, "Must be 21 or older");
+        assert.deepEqual(results.errors.all, ["person", "company"]);
+    });
 
-  it('tests alternative conditional using elseif', function() {
-    var config = {
-      "Person will be in house if person is tired or hungry": {
-        if: {
-          "person.tired": true
-        },
-        elseif:  {
-          "person.hungry": true
-        },
-        then: {
-          "person.location": "house"
-        }
-      }
-    };
-    var data = {
-      person: {
-        tired: false,
-        hungry: true
-      }
-    };
 
-    var rules = new Rules(config);
-    rules.run(data);
+    it('tests alternative outcome if rule validation comes back false', function () {
+        var config = {
+            "Person will be in house if person is tired or hungry": {
+                if: {
+                    "person.tired": true
+                },
+                then: {
+                    "person.location": "house"
+                },
+                elseThen: {
+                    "person.location": 'work'
+                }
+            }
+        };
+        var data = {
+            person: {
+                tired: false,
+                hungry: false
+            }
+        };
 
-    assert.equal(data.person.location, 'house');
-  });
+        var rules = new Rules(config);
+        rules.run(data);
 
-  it("populates multiple outcomes into an array when [] is added", function() {
-    var config = {
-      "Must be 21 or older": {
-        if: {
-          "person.age": { lessThan: 21}
-        },
+        assert.equal(data.person.location, 'work');
+    });
 
-        then: {
-          "errors[]": "Must be 21 or older"
-        }
-      },
-      "Must be employed": {
-        if: {
-          "person.isCitizen": false
-        },
-        then: {
-          "errors[]": "Must be a citizen"
-        }
-      }
-    };
-    var data = {
-      person: {
-        age: 20,
-        isCitizen: false,
-      }
-    };
-    var rules = new Rules(config);
-    var results = rules.run(data);
+    it('tests a series of if conditions (Array), as separate OR rules', function () {
+        var config = {
+            "Person will be in house if person is tired or hungry": {
+                if: [
+                    {"person.tired": true},
+                    {"person.hungry": true}
+                ],
+                then: {
+                    "person.location": "house"
+                },
+                elseThen: {
+                    "person.location": 'work'
+                }
+            }
+        };
+        var data = {
+            person: {
+                tired: false,
+                hungry: true
+            }
+        };
 
-    assert.deepEqual(results.errors, [
-      "Must be 21 or older",
-      "Must be a citizen"
-    ]);
-  });
+        var rules = new Rules(config);
+        rules.run(data);
 
-  it("doesn't throw path errors with strict:false", function() {
-    var config = {
-      "name must be set": {
-        if: {
-          "person.name": { not: undefined }
-        },
-        then: {
-          "errors[]": "Must have a name"
-        },
-      },
-    };
+        assert.equal(data.person.location, 'house');
+    });
 
-    var data = {
-      person: {
-        age: 34
-      },
-    };
-    var rules = new Rules(config);
-    assert.doesNotThrow(function() {
-      rules.run(data);
-    }, "should not throw path errors with strict:false");
-  });
+    it('tests a series of if (OR) conditions, and makes elseThen outcome if all fail', function () {
+        var config = {
+            "Person will be in house if person is tired or hungry": {
+                if: [
+                    {"person.tired": true},
+                    {"person.hungry": true}
+                ],
+                then: {
+                    "person.location": "house"
+                },
+                elseThen: {
+                    "person.location": 'work'
+                }
+            }
+        };
+        var data = {
+            person: {
+                tired: false,
+                hungry: false
+            }
+        };
 
-  it("throws path errors with strict:true", function() {
-    var config = {
-      "name must be set": {
-        if: {
-          "person.name": { not: undefined }
-        },
-        then: {
-          "errors[]": "Must have a name"
-        },
-      },
-    };
+        var rules = new Rules(config);
+        rules.run(data);
 
-    var data = {
-      person: {
-        age: 34
-      },
-    };
-    var rules = new Rules(config, {strict: true});
-    assert.throws(function() {
-      rules.run(data);
-    }, "should throw path errors with strict:false");
-  });
+        assert.equal(data.person.location, 'work');
+    });
 
-  it("doesn't run tests for path errors with strict:false", function() {
-    var config = {
-      "name must be set": {
-        if: {
-          "person.age": { between: [10,20] }
-        },
-        then: {
-          "errors[]": "Must be between 10 and 20"
-        },
-      },
-    };
+    it("populates multiple outcomes into an array when [] is added", function () {
+        var config = {
+            "Must be 21 or older": {
+                if: {
+                    "person.age": {lessThan: 21}
+                },
 
-    var data = {
-      person: {
-        name: "Bob"
-      },
-    };
-    var rules = new Rules(config);
-    rules.run(data);
-  });
+                then: {
+                    "errors[]": "Must be 21 or older"
+                }
+            },
+            "Must be employed": {
+                if: {
+                    "person.isCitizen": false
+                },
+                then: {
+                    "errors[]": "Must be a citizen"
+                }
+            }
+        };
+        var data = {
+            person: {
+                age: 20,
+                isCitizen: false,
+            }
+        };
+        var rules = new Rules(config);
+        var results = rules.run(data);
+
+        assert.deepEqual(results.errors, [
+            "Must be 21 or older",
+            "Must be a citizen"
+        ]);
+    });
+
+    it("doesn't throw path errors with strict:false", function () {
+        var config = {
+            "name must be set": {
+                if: {
+                    "person.name": {not: undefined}
+                },
+                then: {
+                    "errors[]": "Must have a name"
+                },
+            },
+        };
+
+        var data = {
+            person: {
+                age: 34
+            },
+        };
+        var rules = new Rules(config);
+        assert.doesNotThrow(function () {
+            rules.run(data);
+        }, "should not throw path errors with strict:false");
+    });
+
+    it("throws path errors with strict:true", function () {
+        var config = {
+            "name must be set": {
+                if: {
+                    "person.name": {not: undefined}
+                },
+                then: {
+                    "errors[]": "Must have a name"
+                },
+            },
+        };
+
+        var data = {
+            person: {
+                age: 34
+            },
+        };
+        var rules = new Rules(config, {strict: true});
+        assert.throws(function () {
+            rules.run(data);
+        }, "should throw path errors with strict:false");
+    });
+
+    it("doesn't run tests for path errors with strict:false", function () {
+        var config = {
+            "name must be set": {
+                if: {
+                    "person.age": {between: [10, 20]}
+                },
+                then: {
+                    "errors[]": "Must be between 10 and 20"
+                },
+            },
+        };
+
+        var data = {
+            person: {
+                name: "Bob"
+            },
+        };
+        var rules = new Rules(config);
+        rules.run(data);
+    });
 });
 
-describe("options", function() {
-  it("stringNumbers: false prevents parsing of numbers", function() {
-    var data = {age: "14"};
+describe("options", function () {
+    it("stringNumbers: false prevents parsing of numbers", function () {
+        var data = {age: "14"};
 
-    var config = {
-      "Younger than 16 can't drive": {
-        if: {
-          "age": { lessThan: 16}
-        },
-        then: {
-          "canDrive": false
+        var config = {
+            "Younger than 16 can't drive": {
+                if: {
+                    "age": {lessThan: 16}
+                },
+                then: {
+                    "canDrive": false
+                }
+            }
+        };
+
+        var rules = new Rules(config, {stringNumbers: false});
+        var error;
+        try {
+            rules.run(data);
+        } catch (e) {
+            error = true;
         }
-      }
-    };
 
-    var rules = new Rules(config, {stringNumbers: false});
-    var error;
-    try {
-      rules.run(data);
-    } catch(e) {
-      error = true;
-    }
+        assert(error);
+    });
 
-    assert(error);
-  });
+    it("rulesModifyData: false creates new object of rule outcomes", function () {
+        var data = {age: 15};
 
-  it("rulesModifyData: false creates new object of rule outcomes", function() {
-    var data = {age: 15};
+        var config = {
+            "Younger than 16 can't drive": {
+                if: {
+                    "age": {lessThan: 16}
+                },
+                then: {
+                    "cantDrive": true
+                }
+            }
+        };
 
-    var config = {
-      "Younger than 16 can't drive": {
-        if: {
-          "age": { lessThan: 16}
-        },
-        then: {
-          "cantDrive": true
-        }
-      }
-    };
+        var rules = new Rules(config, {rulesModifyData: false});
+        var results = rules.run(data);
 
-    var rules = new Rules(config, {rulesModifyData: false});
-    var results = rules.run(data);
+        assert.equal(results.cantDrive, true);
+        assert.equal(data.cantDrive, undefined);
+    });
 
-    assert.equal(results.cantDrive, true);
-    assert.equal(data.cantDrive, undefined);
-  });
+    it("rulesModifyData: true modifies data with outcomes", function () {
+        var data = {age: 15};
 
-  it("rulesModifyData: true modifies data with outcomes", function() {
-    var data = {age: 15};
+        var config = {
+            "Younger than 16 can't drive": {
+                if: {
+                    "age": {lessThan: 16}
+                },
+                then: {
+                    "cantDrive": true
+                }
+            }
+        };
 
-    var config = {
-      "Younger than 16 can't drive": {
-        if: {
-          "age": { lessThan: 16}
-        },
-        then: {
-          "cantDrive": true
-        }
-      }
-    };
+        var rules = new Rules(config, {rulesModifyData: true});
+        rules.run(data);
 
-    var rules = new Rules(config, {rulesModifyData: true});
-    rules.run(data);
+        assert.equal(data.cantDrive, true);
+    });
 
-    assert.equal(data.cantDrive, true);
-  });
+    it("caseSensitive: false ignores case on contains", function () {
+        var data = {
+            person: {jobDescription: "Nursing management and oversight"}
+        };
 
-  it("caseSensitive: false ignores case on contains", function() {
-    var data = {
-      person: { jobDescription: "Nursing management and oversight" }
-    };
+        var config = {
+            "Anything to do with nursing is a good thing": {
+                if: {
+                    "person.jobDescription": {contains: "nursing"}
+                },
+                then: {"status.hasGoodJob": true}
+            }
+        };
 
-    var config = {
-      "Anything to do with nursing is a good thing": {
-        if: {
-          "person.jobDescription": { contains: "nursing" }
-        },
-        then: { "status.hasGoodJob": true }
-      }
-    };
+        var rules = new Rules(config, {caseSensitive: false});
+        var results = rules.run(data);
 
-    var rules = new Rules(config, {caseSensitive: false});
-    var results = rules.run(data);
+        assert.equal(results.status.hasGoodJob, true);
+    });
 
-    assert.equal(results.status.hasGoodJob, true);
-  });
+    it("caseSensitive: false ignores case on equality", function () {
+        var data = {
+            name: "John"
+        };
 
-  it("caseSensitive: false ignores case on equality", function() {
-    var data = {
-      name: "John"
-    };
+        var config = {
+            "John is a great name": {
+                if: {
+                    "name": "john"
+                },
+                then: {"status.hasGreatName": true}
+            }
+        };
 
-    var config = {
-      "John is a great name": {
-        if: {
-          "name": "john"
-        },
-        then: { "status.hasGreatName": true }
-      }
-    };
+        var rules = new Rules(config, {caseSensitive: false});
+        var results = rules.run(data);
 
-    var rules = new Rules(config, {caseSensitive: false});
-    var results = rules.run(data);
-
-    assert.equal(results.status.hasGreatName, true);
-  });
+        assert.equal(results.status.hasGreatName, true);
+    });
 });

--- a/test/Rules.js
+++ b/test/Rules.js
@@ -1,8 +1,9 @@
 var assert = require("assert");
 var Rules = require("../lib/Rules");
 
-describe("Rules", function () {
-  it("populates multiple outcomes", function () {
+
+describe("Rules", function() {
+  it("populates multiple outcomes", function() {
     var config = {
       "Must be 21 or older": {
         if: {
@@ -40,97 +41,12 @@ describe("Rules", function () {
     assert.deepEqual(results.errors.all, ["person", "company"]);
   });
 
-
-  it("tests alternative outcome if rule validation comes back false", function () {
-    var config = {
-      "Person will be in house if person is tired or hungry": {
-        if: {
-          "person.tired": true
-        },
-        then: {
-          "person.location": "house"
-        },
-        otherwise: {
-          "person.location": "work"
-        }
-      }
-    };
-    var data = {
-      person: {
-        tired: false,
-        hungry: false
-      }
-    };
-
-    var rules = new Rules(config);
-    rules.run(data);
-
-    assert.equal(data.person.location, "work");
-  });
-
-  it("tests a series of if conditions (Array), as separate OR rules", function () {
-    var config = {
-      "Person will be in house if person is tired or hungry": {
-        if: [
-          {"person.tired": true},
-          {"person.hungry": true}
-        ],
-        then: {
-          "person.location": "house"
-        },
-        otherwise: {
-          "person.location": 'work'
-        }
-      }
-    };
-    var data = {
-      person: {
-        tired: false,
-        hungry: true
-      }
-    };
-
-    var rules = new Rules(config);
-    rules.run(data);
-
-    assert.equal(data.person.location, "house");
-  });
-
-  it("tests a series of if (OR) conditions, and applies `otherwise` outcome if all fail", function () {
-    var config = {
-      "Person will be in house if person is tired or hungry": {
-        if: [
-          {"person.tired": true},
-          {"person.hungry": true}
-        ],
-        then: {
-          "person.location": "house"
-        },
-        otherwise: {
-          "person.location": "work"
-        }
-      }
-    };
-    var data = {
-      person: {
-        tired: false,
-        hungry: false
-      }
-    };
-
-    var rules = new Rules(config);
-    rules.run(data);
-
-    assert.equal(data.person.location, "work");
-  });
-
-  it("populates multiple outcomes into an array when [] is added", function () {
+  it("populates multiple outcomes into an array when [] is added", function() {
     var config = {
       "Must be 21 or older": {
         if: {
-          "person.age": {lessThan: 21}
+          "person.age": { lessThan: 21}
         },
-
         then: {
           "errors[]": "Must be 21 or older"
         }
@@ -159,11 +75,11 @@ describe("Rules", function () {
     ]);
   });
 
-  it("doesn't throw path errors with strict:false", function () {
+  it("doesn't throw path errors with strict:false", function() {
     var config = {
       "name must be set": {
         if: {
-          "person.name": {not: undefined}
+          "person.name": { not: undefined }
         },
         then: {
           "errors[]": "Must have a name"
@@ -177,16 +93,16 @@ describe("Rules", function () {
       },
     };
     var rules = new Rules(config);
-    assert.doesNotThrow(function () {
+    assert.doesNotThrow(function() {
       rules.run(data);
     }, "should not throw path errors with strict:false");
   });
 
-  it("throws path errors with strict:true", function () {
+  it("throws path errors with strict:true", function() {
     var config = {
       "name must be set": {
         if: {
-          "person.name": {not: undefined}
+          "person.name": { not: undefined }
         },
         then: {
           "errors[]": "Must have a name"
@@ -200,16 +116,16 @@ describe("Rules", function () {
       },
     };
     var rules = new Rules(config, {strict: true});
-    assert.throws(function () {
+    assert.throws(function() {
       rules.run(data);
     }, "should throw path errors with strict:false");
   });
 
-  it("doesn't run tests for path errors with strict:false", function () {
+  it("doesn't run tests for path errors with strict:false", function() {
     var config = {
       "name must be set": {
         if: {
-          "person.age": {between: [10, 20]}
+          "person.age": { between: [10,20] }
         },
         then: {
           "errors[]": "Must be between 10 and 20"
@@ -227,14 +143,14 @@ describe("Rules", function () {
   });
 });
 
-describe("options", function () {
-  it("stringNumbers: false prevents parsing of numbers", function () {
+describe("options", function() {
+  it("stringNumbers: false prevents parsing of numbers", function() {
     var data = {age: "14"};
 
     var config = {
       "Younger than 16 can't drive": {
         if: {
-          "age": {lessThan: 16}
+          "age": { lessThan: 16}
         },
         then: {
           "canDrive": false
@@ -246,20 +162,20 @@ describe("options", function () {
     var error;
     try {
       rules.run(data);
-    } catch (e) {
+    } catch(e) {
       error = true;
     }
 
     assert(error);
   });
 
-  it("rulesModifyData: false creates new object of rule outcomes", function () {
+  it("rulesModifyData: false creates new object of rule outcomes", function() {
     var data = {age: 15};
 
     var config = {
       "Younger than 16 can't drive": {
         if: {
-          "age": {lessThan: 16}
+          "age": { lessThan: 16}
         },
         then: {
           "cantDrive": true
@@ -274,13 +190,13 @@ describe("options", function () {
     assert.equal(data.cantDrive, undefined);
   });
 
-  it("rulesModifyData: true modifies data with outcomes", function () {
+  it("rulesModifyData: true modifies data with outcomes", function() {
     var data = {age: 15};
 
     var config = {
       "Younger than 16 can't drive": {
         if: {
-          "age": {lessThan: 16}
+          "age": { lessThan: 16}
         },
         then: {
           "cantDrive": true
@@ -294,17 +210,17 @@ describe("options", function () {
     assert.equal(data.cantDrive, true);
   });
 
-  it("caseSensitive: false ignores case on contains", function () {
+  it("caseSensitive: false ignores case on contains", function() {
     var data = {
-      person: {jobDescription: "Nursing management and oversight"}
+      person: { jobDescription: "Nursing management and oversight" }
     };
 
     var config = {
       "Anything to do with nursing is a good thing": {
         if: {
-          "person.jobDescription": {contains: "nursing"}
+          "person.jobDescription": { contains: "nursing" }
         },
-        then: {"status.hasGoodJob": true}
+        then: { "status.hasGoodJob": true }
       }
     };
 
@@ -314,7 +230,7 @@ describe("options", function () {
     assert.equal(results.status.hasGoodJob, true);
   });
 
-  it("caseSensitive: false ignores case on equality", function () {
+  it("caseSensitive: false ignores case on equality", function() {
     var data = {
       name: "John"
     };
@@ -324,7 +240,7 @@ describe("options", function () {
         if: {
           "name": "john"
         },
-        then: {"status.hasGreatName": true}
+        then: { "status.hasGreatName": true }
       }
     };
 

--- a/test/Rules.js
+++ b/test/Rules.js
@@ -1,7 +1,6 @@
 var assert = require("assert");
 var Rules = require("../lib/Rules");
 
-
 describe("Rules", function() {
   it("populates multiple outcomes", function() {
     var config = {
@@ -41,12 +40,40 @@ describe("Rules", function() {
     assert.deepEqual(results.errors.all, ["person", "company"]);
   });
 
+  it('tests alternative conditional using elseif', function() {
+    var config = {
+      "Person will be in house if person is tired or hungry": {
+        if: {
+          "person.tired": true
+        },
+        elseif:  {
+          "person.hungry": true
+        },
+        then: {
+          "person.location": "house"
+        }
+      }
+    };
+    var data = {
+      person: {
+        tired: false,
+        hungry: true
+      }
+    };
+
+    var rules = new Rules(config);
+    rules.run(data);
+
+    assert.equal(data.person.location, 'house');
+  });
+
   it("populates multiple outcomes into an array when [] is added", function() {
     var config = {
       "Must be 21 or older": {
         if: {
           "person.age": { lessThan: 21}
         },
+
         then: {
           "errors[]": "Must be 21 or older"
         }

--- a/test/Rules.js
+++ b/test/Rules.js
@@ -141,6 +141,89 @@ describe("Rules", function() {
     var rules = new Rules(config);
     rules.run(data);
   });
+
+  it("tests alternative outcome if rule validation comes back false", function () {
+    var config = {
+      "Person will be in house if person is tired or hungry": {
+        if: {
+          "person.tired": true
+        },
+        then: {
+          "person.location": "house"
+        },
+        otherwise: {
+          "person.location": "work"
+        }
+      }
+    };
+    var data = {
+      person: {
+        tired: false,
+        hungry: false
+      }
+    };
+
+    var rules = new Rules(config);
+    rules.run(data);
+
+    assert.equal(data.person.location, "work");
+  });
+
+  it("tests a series of if conditions (Array), as separate OR rules", function () {
+    var config = {
+      "Person will be in house if person is tired or hungry": {
+        if: [
+          {"person.tired": true},
+          {"person.hungry": true}
+        ],
+        then: {
+          "person.location": "house"
+        },
+        otherwise: {
+          "person.location": 'work'
+        }
+      }
+    };
+    var data = {
+      person: {
+        tired: false,
+        hungry: true
+      }
+    };
+
+    var rules = new Rules(config);
+    rules.run(data);
+
+    assert.equal(data.person.location, "house");
+  });
+
+  it("tests a series of if (OR) conditions, and applies `otherwise` outcome if all fail", function () {
+    var config = {
+      "Person will be in house if person is tired or hungry": {
+        if: [
+          {"person.tired": true},
+          {"person.hungry": true}
+        ],
+        then: {
+          "person.location": "house"
+        },
+        otherwise: {
+          "person.location": "work"
+        }
+      }
+    };
+    var data = {
+      person: {
+        tired: false,
+        hungry: false
+      }
+    };
+
+    var rules = new Rules(config);
+    rules.run(data);
+
+    assert.equal(data.person.location, "work");
+  });
 });
 
 describe("options", function() {


### PR DESCRIPTION
I've added the ability to firstly allow an array of `if` rules objects, acting as a series of OR blocks, meaning if at least one of the sets of rules proves true, the `then` outcomes will run.

Also, if all rules returns false, then a new outcome, an `elseThen` outcome will be run (if it's present). This allows alternative behaviour when the rules do not pass. This applies to one set of rules or an array of sets of rules.