### PR TITLE
Whoops. null is a valid value for a property.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ assert.deepEqual(data.errors.all, ["person", "company"]);
 ```
 
 
-#Use an array of `if` statements to treat conditions as `else if` or `OR like`
+##Use an array of `if` statements to treat conditions as `else if` or `OR like`
 
 ```js
 
@@ -90,7 +90,7 @@ rules.run(data);
 assert.equal(data.person.location, 'house');
 ```
 
-#`otherwise` will process if no conditions match
+##`otherwise` will process if no conditions match
 
 ```js
 

--- a/lib/Rules.js
+++ b/lib/Rules.js
@@ -80,10 +80,6 @@ Rules.prototype.testsMatch = function(tests, data){
     expected = tests[testKeys[i]];
     actual = path.get(data, testKeys[i]);
 
-    if ([null, undefined].indexOf(actual) !== -1) {
-      return false;
-    }
-
     if (!this.runTest(expected, actual)) {
       return;
     }
@@ -93,7 +89,7 @@ Rules.prototype.testsMatch = function(tests, data){
 };
 
 Rules.prototype.runTest = function(expected, actual) {
-  if (typeof expected === "object") {
+  if (typeof expected === "object" && expected !== null) {
     var comparator = Object.keys(expected)[0];
     if (!this.comparators[comparator]) {
       throw new Error("Unknown comparator: " + comparator);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rules-runner",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A JS business rules engine for node",
   "keywords": [
     "business rules",

--- a/test/equality.js
+++ b/test/equality.js
@@ -61,4 +61,52 @@ describe("equality comparator", function() {
 
     assert.equal(results.status.bonus, 500);
   });
+
+  it("matches null values", function() {
+    var data = {
+      person: {
+        profile: null,
+      }
+    };
+
+    var config = {
+      "Null profile gets a flag": {
+        if: {
+          "person.profile": null,
+        },
+        then: {
+          "status.flag": true,
+        }
+      }
+    };
+
+    var rules = new Rules(config);
+    var results = rules.run(data);
+
+    assert.equal(results.status.flag, true);
+  });
+
+  it("matches undefined values", function() {
+    var data = {
+      person: {
+        profile: undefined,
+      }
+    };
+
+    var config = {
+      "Undefined profile gets a flag": {
+        if: {
+          "person.profile": undefined,
+        },
+        then: {
+          "status.flag": true,
+        }
+      }
+    };
+
+    var rules = new Rules(config);
+    var results = rules.run(data);
+
+    assert.equal(results.status.flag, true);
+  });
 });


### PR DESCRIPTION
So, I was mistaken in #6.

The fact of the matter is, `null` is indeed a valid value, especially in forms where _the user never explicitly sets a value_ (e.g. a checkbox).

``` diff
diff --git a/lib/Rules.js b/lib/Rules.js
index c736acb..a6a0a67 100644
--- a/lib/Rules.js
+++ b/lib/Rules.js
@@ -48,7 +48,7 @@ Rules.prototype.testsMatch = function(tests, data){
     expected = tests[testKeys[i]];
     actual = path.get(data, testKeys[i]);

-    if ([null, undefined].indexOf(actual) !== -1) {
+    if ([undefined].indexOf(actual) !== -1) {
       return false;
     }
```

Although, I suppose this is cleaner:

``` diff
diff --git a/lib/Rules.js b/lib/Rules.js
index c736acb..a3e8bd7 100644
--- a/lib/Rules.js
+++ b/lib/Rules.js
@@ -48,7 +48,7 @@ Rules.prototype.testsMatch = function(tests, data){
     expected = tests[testKeys[i]];
     actual = path.get(data, testKeys[i]);

-    if ([null, undefined].indexOf(actual) !== -1) {
+    if (actual === undefined) {
       return false;
     }
```

This would be a backwards incompatible change.
